### PR TITLE
Add support for Ubuntu 14.04 Trusty

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -16,6 +16,12 @@ platforms:
     attributes:
       java:
         jdk_version: 7
+  - name: ubuntu-14.04
+    run_list:
+      - recipe[apt]
+    driver_config:
+      box: opscode-ubuntu-14.04
+      box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-14.04_chef-provisionerless.box
 
 suites:
   - name: mesosphere_master

--- a/metadata.rb
+++ b/metadata.rb
@@ -16,6 +16,7 @@ recipe           "mesos::docker-executor", "install mesos-docker executor"
 depends          'java'
 depends          'python'
 depends          'build-essential'
+depends          'ulimit'
 suggests         'docker'
 
 attribute           "mesos/type",

--- a/recipes/mesosphere.rb
+++ b/recipes/mesosphere.rb
@@ -7,7 +7,17 @@
 # All rights reserved - Do Not Redistribute
 #
 version = node[:mesos][:version]
-download_url = "http://downloads.mesosphere.io/master/#{node['platform']}/#{node['platform_version']}/mesos_#{version}_amd64.deb"
+
+# For now we need to use the latest 13.x based deb
+# package until a trusty mesos deb is available
+# from the mesosphere site.
+if node['platform_version'] == '14.04'
+  platform_version = '13.10'
+else
+  platform_version = node['platform_version']
+end
+
+download_url = "http://downloads.mesosphere.io/master/#{node['platform']}/#{platform_version}/mesos_#{version}_amd64.deb"
 
 # TODO(everpeace) platform_version validation
 if !platform?("ubuntu") then


### PR DESCRIPTION
This pull request adds some logic that allows Ubuntu Trusty (14.04) nodes to install the latest downloadable mesosphere mesos package which is 13.10.  This change can be reverted once Ubuntu 14.10 packages are available from the Mesosphere.io downloads page.
