### PR TITLE
Add CentOS 7 support for mesosphere install

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -150,9 +150,16 @@ module Helpers
           version "#{mesos_version}#{build_version}"
         end
       when 'centos'
+        repo_url = value_for_platform(
+          'centos' => {
+            '6' => 'http://repos.mesosphere.io/el/6/noarch/RPMS/mesosphere-el-repo-6-2.noarch.rpm',
+            '7.0.1406' => 'http://repos.mesosphere.io/el/7/noarch/RPMS/mesosphere-el-repo-7-1.noarch.rpm'
+          },
+        )
+
         bash "add mesosphere repository" do
           code <<-EOH
-            rpm -Uvh http://repos.mesosphere.io/el/6/noarch/RPMS/mesosphere-el-repo-6-2.noarch.rpm || true
+            rpm -Uvh #{repo_url} || true
           EOH
           action :run
         end


### PR DESCRIPTION
We're using this cookbook in production at Brigade, but unfortunately we are forced to use `node[:mesos][:type] = 'source'` because we are on CentOS 7 and the mesophere build of mesos for CentOS 6.5 understandably doesn't work on CentOS 7.

It takes a long time to build Mesos, especially given that Mesosphere has done all the hard work for us, we just need to swap out the URL.

This commit adds a simple conditional which swaps out the URL to the mesosphere repo based on the version of CentOS.

Let me know how this looks. Thanks for the great, well-tested, cookbook!
