### PR TITLE
Allow the use of a hash to populate the /etc/mesos-[slave|master]/* config files

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -46,6 +46,8 @@ suites:
       mesos:
         type: mesosphere
         slave:
+          attributes:
+            rackid: us-east-1b
           master: 'zk://localhost:2181/mesos'
         # these keys below are only for master configurations.
         master_ips: ['10.0.0.1', '10.0.0.2', '10.0.0.3']

--- a/libraries/hash.rb
+++ b/libraries/hash.rb
@@ -1,0 +1,21 @@
+class Hash
+  # rubocop:disable LineLength
+  def to_path_hash(separator = nil)
+    paths.map do |pathname|
+      {
+        path: separator ? pathname[0..-2].join(separator) : File.join(pathname[0..-2]),
+        content: pathname.last
+      }
+    end
+  end
+  # rubocop:enable LineLength
+
+  private
+
+  def paths
+    map do |path, opts|
+      sub_path = opts.respond_to?(:paths) ? opts.paths : opts.to_s
+      [path.to_s, sub_path].flatten
+    end
+  end
+end

--- a/spec/recipes/master_spec.rb
+++ b/spec/recipes/master_spec.rb
@@ -130,10 +130,13 @@ describe 'mesos::master' do
     end
 
     describe 'configuration options in /etc/mesos-master' do
-      it 'echos each key-value pair in node[:mesos][:master]' do
-        expect(chef_run).to run_bash('echo /tmp/mesos > /etc/mesos-master/work_dir')
-        expect(chef_run).to run_bash('echo 1 > /etc/mesos-master/quorum')
-        expect(chef_run).to run_bash('echo fake_value > /etc/mesos-master/fake_key')
+      it 'sets content to each key-value pair in node[:mesos][:master]' do
+        expect(chef_run).to render_file('/etc/mesos-master/work_dir')
+          .with_content(%r{^/tmp/mesos$})
+        expect(chef_run).to render_file('/etc/mesos-master/quorum')
+          .with_content(/^1$/)
+        expect(chef_run).to render_file('/etc/mesos-master/fake_key')
+          .with_content(/^fake_value$/)
       end
     end
   end

--- a/spec/recipes/slave_spec.rb
+++ b/spec/recipes/slave_spec.rb
@@ -34,6 +34,7 @@ describe 'mesos::slave' do
         node.set[:mesos][:slave][:master] = 'test-master'
         node.set[:mesos][:mesosphere][:with_zookeeper] = true
         node.set[:mesos][:slave][:slave_key] = 'slave_value'
+        node.set[:mesos][:slave][:attributes][:rackid] = 'us-east-1b'
       end.converge(described_recipe)
     end
 
@@ -75,9 +76,13 @@ describe 'mesos::slave' do
     end
 
     describe 'configuration options in /etc/mesos-slave' do
-      it 'echos each key-value pair in node[:mesos][:slave]' do
-        expect(chef_run).to run_bash('echo /tmp/mesos > /etc/mesos-slave/work_dir')
-        expect(chef_run).to run_bash('echo slave_value > /etc/mesos-slave/slave_key')
+      it 'sets content to each key-value pair in node[:mesos][:slave]' do
+        expect(chef_run).to render_file('/etc/mesos-slave/work_dir')
+          .with_content(%r{^/tmp/mesos$})
+        expect(chef_run).to render_file('/etc/mesos-slave/slave_key')
+          .with_content(/^slave_value$/)
+        expect(chef_run).to render_file('/etc/mesos-slave/attributes/rackid')
+          .with_content(/^us-east-1b$/)
       end
     end
   end
@@ -89,6 +94,7 @@ describe 'mesos::slave' do
         node.set[:mesos][:slave][:master] = 'test-master'
         node.set[:mesos][:slave][:slave_key] = 'slave_value'
         node.set[:mesos][:build][:skip_test] = false
+        node.set[:mesos][:slave][:attributes][:rackid] = 'us-east-1b'
       end.converge(described_recipe)
     end
 

--- a/templates/default/mesos-master-env.sh.erb
+++ b/templates/default/mesos-master-env.sh.erb
@@ -5,7 +5,13 @@
 
 <% if node[:mesos][:master] %>
   <% node[:mesos][:master].each do |key, val| %>
+    <% if val.respond_to?(:to_path_hash) -%>
+      <% val.to_path_hash('_').each do |path_h| -%>
+export MESOS_<%= key %>_<%= path_h[:path] %>=<%= path_h[:content] %>
+      <% end -%>
+    <% else -%>
 export MESOS_<%= key %>=<%= val %>
+    <% end -%>
   <% end %>
 <% end %>
 

--- a/templates/default/mesos-slave-env.sh.erb
+++ b/templates/default/mesos-slave-env.sh.erb
@@ -10,7 +10,13 @@
 
 <% if node[:mesos][:slave] %>
   <% node[:mesos][:slave].each do |key, val| %>
+    <% if val.respond_to?(:to_path_hash) -%>
+      <% val.to_path_hash('_').each do |path_h| -%>
+export MESOS_<%= key %>_<%= path_h[:path] %>=<%= path_h[:content] %>
+      <% end -%>
+    <% else -%>
 export MESOS_<%= key %>=<%= val %>
+    <% end -%>
   <% end %>
 <% end %>
 

--- a/test/integration/helpers/serverspec/slave_configuration.rb
+++ b/test/integration/helpers/serverspec/slave_configuration.rb
@@ -39,6 +39,24 @@ shared_examples_for 'a configuration of a slave node' do
     it 'contains isolation variable' do
       expect(slave_env_file.content).to match /^export MESOS_isolation=cgroups$/
     end
+
+    it 'contains rackid variable' do
+      expect(slave_env_file.content).to match(/^export MESOS_attributes_rackid=us-east-1b$/)
+    end
+  end
+
+  describe 'rack id file' do
+    let :rack_id_file do
+      file '/etc/mesos-slave/attributes/rackid'
+    end
+
+    it 'creates it' do
+      expect(rack_id_file).to be_a_file
+    end
+
+    it 'contains a rack id' do
+      expect(rack_id_file.content).to match(/^us-east-1b$/)
+    end
   end
 
   describe service('mesos-slave') do


### PR DESCRIPTION
This should make it much easier and more straightforward to set attributes that need to go in subdirectories (such as `/etc/mesos-slave/attributes/rackid`).