### PR TITLE
Make the unit tests succeed for Mesosphere on Ubuntu 1404

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,6 +1,7 @@
 ---
 driver:
   name: vagrant
+  require_chef_omnibus: 11.16.4
   customize:
     memory: 2048
     cpus: 2

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -48,6 +48,9 @@ suites:
         type: mesosphere
         slave:
           master: 'zk://localhost:2181/mesos'
+        master:
+          zk: 'zk://localhost:2181/mesos'
+          quorum: 1
         # these keys below are only for master configurations.
         master_ips: ['10.0.0.1', '10.0.0.2', '10.0.0.3']
         slave_ips:  ['11.0.0.1', '11.0.0.2', '11.0.0.3']
@@ -72,7 +75,9 @@ suites:
       mesos:
         type: source
         master:
+          zk: 'zk://localhost:2181/mesos'
           ip: 127.0.0.1
+          quorum: 1
         slave:
           master: 127.0.0.1:5050
         # these keys below are only for master configurations.

--- a/test/integration/helpers/serverspec/slave_configuration.rb
+++ b/test/integration/helpers/serverspec/slave_configuration.rb
@@ -37,7 +37,7 @@ shared_examples_for 'a configuration of a slave node' do
     end
 
     it 'contains isolation variable' do
-      expect(slave_env_file.content).to match /^export MESOS_isolation=cgroups$/
+      expect(slave_env_file.content).to match /^export MESOS_isolation=cgroups\/cpu,cgroups\/mem$/
     end
   end
 

--- a/test/integration/helpers/serverspec/spec_helper.rb
+++ b/test/integration/helpers/serverspec/spec_helper.rb
@@ -1,10 +1,7 @@
 # encoding: utf-8
-
 require 'serverspec'
-require 'pathname'
 
-include Serverspec::Helper::Exec
-include Serverspec::Helper::DetectOS
+set :backend, :exec
 
 require 'mesosphere_installation'
 require 'source_installation'

--- a/test/integration/mesosphere_master/serverspec/localhost/mesosphere_master_spec.rb
+++ b/test/integration/mesosphere_master/serverspec/localhost/mesosphere_master_spec.rb
@@ -62,10 +62,6 @@ describe 'mesos::master' do
       it 'creates it' do
         expect(file('/etc/mesos-master')).to be_a_directory
       end
-
-      it 'is empty' do
-        expect(Dir.glob('/etc/mesos-master/*')).to be_empty
-      end
     end
   end
 end

--- a/test/integration/mesosphere_slave/serverspec/localhost/mesosphere_slave_spec.rb
+++ b/test/integration/mesosphere_slave/serverspec/localhost/mesosphere_slave_spec.rb
@@ -54,7 +54,7 @@ describe 'mesos::slave' do
       end
 
       it 'contains ISOLATION variable' do
-        expect(slave_file.content).to match /^ISOLATION=cgroups$/
+        expect(slave_file.content).to match /^ISOLATION=cgroups\/cpu,cgroups\/mem$/
       end
     end
 


### PR DESCRIPTION
Tests for `mesosphere-master-ubuntu-1404` and `mesosphere-slave-ubuntu-1404` were not passing because the test conditions had not been updated to include newly added attributes.  This should take care of that.