### PR TITLE
Helpers modules can clash with Helpers module from other cookbooks

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -34,14 +34,14 @@ module Helpers
 
 
   module Mesosphere extend Helpers::Mesos
-    Chef::Resource::Bash.send(:include, Helpers::Mesos)
-    Chef::Resource::Bash.send(:include, Helpers::Mesosphere)
-    Chef::Resource::Package.send(:include, Helpers::Mesos)
-    Chef::Resource::Package.send(:include, Helpers::Mesosphere)
-    Chef::Resource::Service.send(:include, Helpers::Mesos)
-    Chef::Resource::Service.send(:include, Helpers::Mesosphere)
-    Chef::Resource::Template.send(:include, Helpers::Mesos)
-    Chef::Resource::Template.send(:include, Helpers::Mesosphere)
+    Chef::Resource::Bash.send(:include, ::Helpers::Mesos)
+    Chef::Resource::Bash.send(:include, ::Helpers::Mesosphere)
+    Chef::Resource::Package.send(:include, ::Helpers::Mesos)
+    Chef::Resource::Package.send(:include, ::Helpers::Mesosphere)
+    Chef::Resource::Service.send(:include, ::Helpers::Mesos)
+    Chef::Resource::Service.send(:include, ::Helpers::Mesosphere)
+    Chef::Resource::Template.send(:include, ::Helpers::Mesos)
+    Chef::Resource::Template.send(:include, ::Helpers::Mesosphere)
 
     unless (const_defined?(:MESOSPHERE_INFO))
       MESOSPHERE_INFO = {

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'everpeace@gmail.com'
 license          'MIT'
 description      'Installs/Configures mesos'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.2.1'
+version          '0.2.2'
 
 supports         'ubuntu', '>= 12.04'
 supports         'centos', '>= 6.0'

--- a/recipes/build_from_source.rb
+++ b/recipes/build_from_source.rb
@@ -3,16 +3,16 @@
 # Recipe:: install
 #
 
-::Chef::Recipe.send(:include, Helpers::Mesos)
-::Chef::Recipe.send(:include, Helpers::Source)
-Chef::Resource::Bash.send(:include, Helpers::Mesos)
-Chef::Resource::Bash.send(:include, Helpers::Source)
-Chef::Resource::RemoteFile.send(:include, Helpers::Mesos)
-Chef::Resource::RemoteFile.send(:include, Helpers::Source)
-Chef::Resource::Template.send(:include, Helpers::Mesos)
-Chef::Resource::Template.send(:include, Helpers::Source)
-Chef::Resource::Service.send(:include, Helpers::Mesos)
-Chef::Resource::Service.send(:include, Helpers::Source)
+::Chef::Recipe.send(:include, ::Helpers::Mesos)
+::Chef::Recipe.send(:include, ::Helpers::Source)
+Chef::Resource::Bash.send(:include, ::Helpers::Mesos)
+Chef::Resource::Bash.send(:include, ::Helpers::Source)
+Chef::Resource::RemoteFile.send(:include, ::Helpers::Mesos)
+Chef::Resource::RemoteFile.send(:include, ::Helpers::Source)
+Chef::Resource::Template.send(:include, ::Helpers::Mesos)
+Chef::Resource::Template.send(:include, ::Helpers::Source)
+Chef::Resource::Service.send(:include, ::Helpers::Mesos)
+Chef::Resource::Service.send(:include, ::Helpers::Source)
 
 if !(installed?) then
   include_dependency_recipes

--- a/recipes/master.rb
+++ b/recipes/master.rb
@@ -3,11 +3,11 @@
 # Recipe:: master
 #
 
-::Chef::Recipe.send(:include, Helpers::Mesos)
+::Chef::Recipe.send(:include, ::Helpers::Mesos)
 if node[:mesos][:type] == 'source' then
-  ::Chef::Recipe.send(:include, Helpers::Source)
+  ::Chef::Recipe.send(:include, ::Helpers::Source)
 elsif node[:mesos][:type] == 'mesosphere' then
-  ::Chef::Recipe.send(:include, Helpers::Mesosphere)
+  ::Chef::Recipe.send(:include, ::Helpers::Mesosphere)
   Chef::Log.info("node[:mesos][:prefix] is ignored. prefix will be set with /usr/local .")
 else
   Chef::Application.fatal!("node['mesos']['type'] should be 'source' or 'mesosphere'.")

--- a/recipes/mesosphere.rb
+++ b/recipes/mesosphere.rb
@@ -3,9 +3,9 @@
 # Recipe:: mesosphere
 #
 
-::Chef::Recipe.send(:include, Helpers::Mesos)
-::Chef::Recipe.send(:include, Helpers::Mesosphere)
-Chef::Resource::Service.send(:include, Helpers::Mesos)
+::Chef::Recipe.send(:include, ::Helpers::Mesos)
+::Chef::Recipe.send(:include, ::Helpers::Mesosphere)
+Chef::Resource::Service.send(:include, ::Helpers::Mesos)
 
 # TODO(everpeace) platform_version validation
 if !platform_supported? then

--- a/recipes/slave.rb
+++ b/recipes/slave.rb
@@ -3,11 +3,11 @@
 # Recipe:: slave
 #
 
-::Chef::Recipe.send(:include, Helpers::Mesos)
+::Chef::Recipe.send(:include, ::Helpers::Mesos)
 if node[:mesos][:type] == 'source' then
-  ::Chef::Recipe.send(:include, Helpers::Source)
+  ::Chef::Recipe.send(:include, ::Helpers::Source)
 elsif node[:mesos][:type] == 'mesosphere' then
-  ::Chef::Recipe.send(:include, Helpers::Mesosphere)
+  ::Chef::Recipe.send(:include, ::Helpers::Mesosphere)
   Chef::Log.info("node[:mesos][:prefix] is ignored. prefix will be set with /usr/local .")
 else
   Chef::Application.fatal!("node['mesos']['type'] should be 'source' or 'mesosphere'.")


### PR DESCRIPTION
The name is quite generic so it can often clash with Helpers in other cookbook (had the problem with the Apt cookbook).

This PR prevents it from happening.